### PR TITLE
Use banner images for portal links

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -5,15 +5,19 @@ import Link from "next/link"
 export default function Header() {
   return (
     <header className="fixed top-0 left-0 w-full h-10 bg-white shadow-md z-50 flex items-center px-6">
-      <div className="ml-auto">
-        <Link href="/" className="ml-3 text-sm text-blue-600 hover:underline">
-            🌀 ポータル
+      <div className="ml-auto flex items-center space-x-3">
+        <Link href="/" className="block h-8">
+          <img src="/civoppi.png" alt="ポータル" className="h-full" />
         </Link>
-        <Link href="/orideco" className="ml-3 text-sm text-blue-600 hover:underline">
-            👚 オリジナルグッズを作ろう！
+        <Link href="/orideco" className="block h-8">
+          <img
+            src="/oridecobanner.png"
+            alt="オリジナルグッズを作ろう"
+            className="h-full"
+          />
         </Link>
       </div>
-      <p className="mt-auto ml-auto text-xs">v{pkg.version}</p>
+      <p className="ml-3 text-xs">v{pkg.version}</p>
       
     </header>
   );


### PR DESCRIPTION
## Summary
- update header links with banner images for Portal and オリジナルグッズ

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b89717c84832798c99c5dbccbede5