### PR TITLE
Use mascot image as root page background

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,15 @@ import Link from 'next/link';
 
 export default function PortalPage() {
   return (
-    <main className="flex flex-col items-center justify-center h-full relative p-4">
+    <main
+      className="flex flex-col items-center justify-center h-full relative p-4"
+      style={{
+        backgroundImage: "url('/mascot.png')",
+        backgroundPosition: 'right center',
+        backgroundRepeat: 'no-repeat',
+        backgroundSize: 'contain',
+      }}
+    >
       <ul className="space-y-2">
         <li>
           <Link href="/orideco" className="text-blue-600 hover:underline">
@@ -15,7 +23,6 @@ export default function PortalPage() {
           </Link>
         </li>
       </ul>
-      <img src="/mascot.png" alt="Mascot" className="absolute right-4 top-1/2 -translate-y-1/2 h-128 w-100" />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- set `mascot.png` as the background of the homepage

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b927c82088327b51457110ebc22ec