### PR TITLE
Add item field to design elements

### DIFF
--- a/components/orideco/DesignElementContext.tsx
+++ b/components/orideco/DesignElementContext.tsx
@@ -5,6 +5,7 @@ import React, { createContext, useState, ReactNode } from 'react';
 // 共通型 Base
 export interface BaseElement {
   id: string;
+  item: 'tshirt' | 'toto';
   type: 'image'|'text';
   position: { x: number; y: number };
   rotate: number;
@@ -82,9 +83,12 @@ export const DesignElementProvider = ({ children }: { children: ReactNode }) => 
     const parsed : BaseElement[] = JSON.parse(data.meta);
 
     parsed.forEach((element)=>{
+      if(!('item' in element)){
+        (element as BaseElement).item = 'tshirt';
+      }
       if(isTextBean(element)){
         add(element);
-        return;        
+        return;
       }
       if(isImageBean(element)){
         element.file = data.images[element.id];


### PR DESCRIPTION
## Summary
- extend `BaseElement` with `item` field
- default missing items to `tshirt` when loading data
- track current item in `ItemEditor` and include it in new elements
- switch editor item to uploaded item's type on zip import

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685175b595648327b05240f08ff2c061