### PR TITLE
Disable preview on unsupported items

### DIFF
--- a/components/orideco/ItemEditor.tsx
+++ b/components/orideco/ItemEditor.tsx
@@ -418,8 +418,9 @@ export default function ItemEditor({ item }: { item: 'tshirt' | 'toto' }) {
         >画像追加</button>
 
         <button
-          className="mt-3 bg-purple-500 text-white px-3 py-1 rounded"
+          className="mt-3 bg-purple-500 text-white px-3 py-1 rounded disabled:bg-gray-300 disabled:text-gray-500 disabled:cursor-not-allowed"
           onClick={() => setShowPreview(true)}
+          disabled={!sides[currentItem].sideMap3D}
         >デザイン確認</button>
 
         <input


### PR DESCRIPTION
## Summary
- disable the design preview button when the current item lacks a 3D model

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853813d02c08327aae6a5430d34799a